### PR TITLE
Feature/choose show design

### DIFF
--- a/app/Http/Controllers/DesignController.php
+++ b/app/Http/Controllers/DesignController.php
@@ -145,7 +145,8 @@ class DesignController extends Controller
             $design = Product::create([
                 'name' => $request['name'],
                 'description' => $request['description'],
-                'category_id' => $request['category']
+                'category_id' => $request['category'],
+                'is_showcase' => $request['is_showcase']
             ]);
 
             if ($request->hasFile('images')) {

--- a/app/Http/Controllers/DesignController.php
+++ b/app/Http/Controllers/DesignController.php
@@ -41,7 +41,8 @@ class DesignController extends Controller
                 'name' => $request->name,
                 'description' => $request->description,
                 'category_id' => $request->category,
-                'main_image' => $request->main_image
+                'main_image' => $request->main_image,
+                'is_showcase' => $request->is_showcase
             ]);
 
             $design->save();

--- a/app/Http/Requests/StoreDesignRequest.php
+++ b/app/Http/Requests/StoreDesignRequest.php
@@ -28,7 +28,8 @@ class StoreDesignRequest extends FormRequest
             'tags' => 'required|array',
             'tags.*' => 'exists:tags,id',
             'images.*' => 'required|image|mimes:jpeg,png,jpg,gif|max:10240',
-            'main-image' => 'required|integer'
+            'main-image' => 'required|integer',
+            'is_showcase' => 'required|boolean',
         ];
     }
 }

--- a/app/Http/Requests/UpdateDesignRequest.php
+++ b/app/Http/Requests/UpdateDesignRequest.php
@@ -28,7 +28,8 @@ class UpdateDesignRequest extends FormRequest
             'tags' => 'sometimes|array',
             'tags.*' => 'exists:tags,id',
             'images.*' => 'sometimes|image|mimes:jpeg,png,jpg,gif|max:10240',
-            'main-image' => 'sometimes|integer'
+            'main-image' => 'sometimes|integer',
+            'is_showcase' => 'sometimes|boolean',
         ];
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -14,6 +14,7 @@ class Product extends Model
         'description',
         'category_id',
         'main_image',
+        'is_showcase',
     ];
 
     public function Category()

--- a/database/migrations/2025_03_02_063220_create_products_table.php
+++ b/database/migrations/2025_03_02_063220_create_products_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->text('slug');
             $table->unsignedBigInteger('category_id'); // Foreign key to category
             $table->unsignedBigInteger('main_image')->nullable(); // Foreign key to image
+            $table->boolean('is_showcase')->default(false);
             $table->timestamps();
 
             // Foreign Key Constraints

--- a/resources/views/admin/design/partials/add-design-form.blade.php
+++ b/resources/views/admin/design/partials/add-design-form.blade.php
@@ -72,6 +72,17 @@
                                 </div>
 
                                 <div>
+                                    <x-input-label for="is_showcase" :value="__('Is Design Show On Home Page')" />
+                                    <div class="mt-1"></div>
+                                    <x-select-input name="is_showcase" class="mt-1 block w-full">
+                                        <option value="0">No</option>
+                                        <option value="1">Yes
+                                        </option>
+                                    </x-select-input>
+                                    <x-input-error class="mt-2" :messages="$errors->get('category')" />
+                                </div>
+
+                                <div>
                                     <button class="btn btn-error" type="button" onclick="window.history.back()">
                                         Cancel
                                     </button>

--- a/resources/views/admin/design/partials/datatables.blade.php
+++ b/resources/views/admin/design/partials/datatables.blade.php
@@ -14,7 +14,7 @@
                                 <th>Main Image</th>
                                 <th>Category</th>
                                 <th>Tag</th>
-                                <th>Is Show Case</th>
+                                <th>Is Show On Homepage</th>
                                 <th>Action</th>
                             </tr>
                         </thead>
@@ -41,10 +41,10 @@
                                         @endforeach
                                     </td>
                                     <td>
-                                        @if ($design->is_show_case)
-                                            <span class="badge badge-success">Show case</span>
+                                        @if ($design->is_showcase)
+                                            <span class="badge badge-success">Show</span>
                                         @else
-                                            <span class="badge badge-danger">Not show case</span>
+                                            <span class="badge badge-danger">Not show</span>
                                         @endif
                                     </td>
                                     <td>
@@ -64,7 +64,7 @@
                                 <th>Main Image</th>
                                 <th>Category</th>
                                 <th>Tag</th>
-                                <th>Is Show Case</th>
+                                <th>Is Show On Homepage</th>
                                 <th>Action</th>
                             </tr>
                         </tfoot>

--- a/resources/views/admin/design/partials/datatables.blade.php
+++ b/resources/views/admin/design/partials/datatables.blade.php
@@ -14,6 +14,7 @@
                                 <th>Main Image</th>
                                 <th>Category</th>
                                 <th>Tag</th>
+                                <th>Is Show Case</th>
                                 <th>Action</th>
                             </tr>
                         </thead>
@@ -40,6 +41,13 @@
                                         @endforeach
                                     </td>
                                     <td>
+                                        @if ($design->is_show_case)
+                                            <span class="badge badge-success">Show case</span>
+                                        @else
+                                            <span class="badge badge-danger">Not show case</span>
+                                        @endif
+                                    </td>
+                                    <td>
                                         <a href="{{ route('designs.edit', $design->id) }}"
                                             class="btn btn-sm btn-primary">Edit</a>
                                         <button class="btn btn-sm btn-error"
@@ -56,6 +64,7 @@
                                 <th>Main Image</th>
                                 <th>Category</th>
                                 <th>Tag</th>
+                                <th>Is Show Case</th>
                                 <th>Action</th>
                             </tr>
                         </tfoot>

--- a/resources/views/admin/design/partials/edit-design-form.blade.php
+++ b/resources/views/admin/design/partials/edit-design-form.blade.php
@@ -78,13 +78,30 @@
                                     <div class="mt-1"></div>
                                     <x-select-input name="main_image" id="main-image-select" class="mt-1 block w-full">
                                         @foreach ($design->Images as $image)
-                                            <option value="{{ $image->id }}" id = "main-image-select-{{ $image->id }}"
+                                            <option value="{{ $image->id }}"
+                                                id = "main-image-select-{{ $image->id }}"
                                                 {{ $design->main_image == $image->id ? 'selected' : '' }}>
                                                 {{ "Image $image->id: " . basename($image->url) }}
                                             </option>
                                         @endforeach
                                     </x-select-input>
                                     <x-input-error class="mt-2" :messages="$errors->get('main_image')" />
+                                </div>
+
+                                <div>
+                                    <x-input-label for="is_showcase" :value="__('Is Design Show On Home Page')" />
+                                    <div class="mt-1"></div>
+                                    <x-select-input name="is_showcase" class="mt-1 block w-full">
+                                        <option value="0"
+                                            {{ old('is_showcase', $design->is_showcase) == 0 ? 'selected' : '' }}>
+                                            No
+                                        </option>
+                                        <option value="1"
+                                            {{ old('is_showcase', $design->is_showcase) == 1 ? 'selected' : '' }}>
+                                            Yes
+                                        </option>
+                                    </x-select-input>
+                                    <x-input-error class="mt-2" :messages="$errors->get('category')" />
                                 </div>
 
                                 <div>


### PR DESCRIPTION
This pull request introduces the "is_showcase" feature to the design management system. This feature allows designs to be marked as showcased, which can be used to display them on the homepage. The changes span across multiple files, including controllers, request validation, models, database migrations, and views.

### Feature Addition: "is_showcase"

* [`app/Http/Controllers/DesignController.php`](diffhunk://#diff-628ae095f24952d9c993503f415f6d8a05908300c790765417c805aeaa588ef2L44-R45): Added `is_showcase` attribute to the `update` and `store` methods to handle the new field. [[1]](diffhunk://#diff-628ae095f24952d9c993503f415f6d8a05908300c790765417c805aeaa588ef2L44-R45) [[2]](diffhunk://#diff-628ae095f24952d9c993503f415f6d8a05908300c790765417c805aeaa588ef2L148-R150)

* `app/Http/Requests/StoreDesignRequest.php` and `app/Http/Requests/UpdateDesignRequest.php`: Updated validation rules to include `is_showcase` as a required boolean field. [[1]](diffhunk://#diff-439cea18166e97aa152b7a233a8fd20aaf15fa112102893f3dcc1ffa594d667fL31-R32) [[2]](diffhunk://#diff-3af31ace0ae09458f60d6117235e8e5a9730095080dff140c5f2f8591be31bf5L31-R32)

* [`app/Models/Product.php`](diffhunk://#diff-1da0d5aacddff592064d76b093770e155db5c7867d79ef77aa775fe22d339d47R17): Added `is_showcase` to the list of fillable attributes in the `Product` model.

* [`database/migrations/2025_03_02_063220_create_products_table.php`](diffhunk://#diff-cb107de0db736105d84f2083701a91d5fc881fb0ed050383230e7654b39abdd2R21): Added a new column `is_showcase` to the `products` table with a default value of `false`.

### UI Updates

* `resources/views/admin/design/partials/add-design-form.blade.php` and `resources/views/admin/design/partials/edit-design-form.blade.php`: Added a new select input for `is_showcase` to the add and edit design forms. [[1]](diffhunk://#diff-883f797ca4877b956d5802ea555af4724f8ff52cd79d865ba86bddb898a82c57R74-R84) [[2]](diffhunk://#diff-99556b569ac9853169d9b804781b1a5dc7c3847ae19944dc26f781aed2d146afR91-R106)

* [`resources/views/admin/design/partials/datatables.blade.php`](diffhunk://#diff-07fb016b633149cee74b663f063674136979fb83a732c3bca498a7e64aebfc60R17): Updated the datatables view to display the `is_showcase` status with badges indicating whether the design is showcased or not. [[1]](diffhunk://#diff-07fb016b633149cee74b663f063674136979fb83a732c3bca498a7e64aebfc60R17) [[2]](diffhunk://#diff-07fb016b633149cee74b663f063674136979fb83a732c3bca498a7e64aebfc60R43-R49) [[3]](diffhunk://#diff-07fb016b633149cee74b663f063674136979fb83a732c3bca498a7e64aebfc60R67)