### PR TITLE
Hotfix for Client, All Pages Fixes

### DIFF
--- a/app/Http/Controllers/client/HomeController.php
+++ b/app/Http/Controllers/client/HomeController.php
@@ -17,11 +17,13 @@ class HomeController extends Controller
         $tags = Tag::latest()->limit(50)->get();
         $categories = Category::latest()->limit(15)->get();
         $products = Product::with(['Category', 'Images', 'Tags'])->latest()->limit(28)->get();
+        $showcaseCategories = Category::where('is_show', 1)->whereNotNull('parent_id')->get();
         return view('client.home.home')->with([
             'title' => $this->PAGE_TITLE,
             'tags' => $tags,
             'categories' => $categories,
-            'products' => $products
+            'products' => $products,
+            'showcaseCategories' => $showcaseCategories
         ]);
     }
 }

--- a/app/Http/Controllers/client/ShopController.php
+++ b/app/Http/Controllers/client/ShopController.php
@@ -159,12 +159,20 @@ class ShopController extends Controller
     public function category($slug)
     {
         $category = Category::where('slug', $slug)->first();
+        $categories = Category::all();
         if (!$category) {
             return redirect()->route('client.shop.index');
         }
+        if ($category->parent_id) {
+            $products = Product::where('category_id', $category->id)->with('Category', 'Images', 'Tags')->paginate(48);
+        } else {
+            $products = Product::whereHas('Category', function ($query) use ($category) {
+                $query->where('parent_id', $category->id);
+            })->with('Category', 'Images', 'Tags')->paginate(48);
+            $categories = Category::where('parent_id', $category->id)->get();
+        }
         $products = $category->Products()->with('Category', 'Images', 'Tags')->paginate(48);
         $tags = Tag::latest()->get()->unique('name');
-        $categories = Category::all();
         return view('client.shop.index')->with([
             'title' => $category->name,
             'products' => $products,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -24,7 +24,8 @@ class AppServiceProvider extends ServiceProvider
         // the try catch block is to prevent the error when the database is not yet migrated
         try {
             // Share categories to all views (so we can display them everywhere)
-            View::share('shared_categories', Category::where('is_show', 1)->latest()->take(50)->get());
+            $parentCategories = Category::where('is_show', 1)->whereNull('parent_id')->latest()->get();
+            View::share('shared_categories', $parentCategories??[]);
         } catch (\Throwable $th) {
         }
     }

--- a/resources/views/client/contact/index.blade.php
+++ b/resources/views/client/contact/index.blade.php
@@ -21,11 +21,7 @@
                         <div class="space-y-4">
                             <div class="flex items-start gap-4">
                                 <div class="bg-primary/10 p-3 rounded-full">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-primary" fill="none"
-                                        viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                            d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
-                                    </svg>
+                                    <img src="{{ asset('images/icons/zalo-light.png') }}" alt="Zalo Icon" class="h-6 w-6 text-primary">
                                 </div>
                                 <a href="https://zalo.me/0908556913" target="_blank" rel="noopener noreferrer"
                                     class="group hover:text-primary transition-colors duration-200">
@@ -39,11 +35,7 @@
 
                             <div class="flex items-start gap-4">
                                 <div class="bg-primary/10 p-3 rounded-full">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-primary" fill="none"
-                                        viewBox="0 0 24 24" stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                            d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
-                                    </svg>
+                                    <img src="{{ asset('images/icons/zalo-light.png') }}" alt="Zalo Icon" class="h-6 w-6 text-primary">
                                 </div>
                                 <a href="https://zalo.me/0975038534" target="_blank" rel="noopener noreferrer"
                                     class="group hover:text-primary transition-colors duration-200">
@@ -97,18 +89,17 @@
                     </div>
                 </div>
 
-                {{-- Map Card --}}
-                {{-- <div class="card bg-base-100 shadow-lg">
+
+            </div>
+            {{-- Map Card --}}
+            <div class="">
+                <div class="card bg-base-100 shadow-lg h-[60%]">
                     <div class="card-body p-0 overflow-hidden rounded-box">
                         <div class="aspect-[16/9]">
-                            <iframe
-                                src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3920.0444663545394!2d106.69758571474399!3d10.732145992347592!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31752f9023a3a85d%3A0xdee5c99a7b02feab!2sNguyen%20Van%20Linh%2C%20Ho%20Chi%20Minh%20City%2C%20Vietnam!5e0!3m2!1sen!2s!4v1647834456950!5m2!1sen!2s"
-                                width="100%" height="100%" style="border:0;" allowfullscreen="" loading="lazy"
-                                class="w-full h-full"></iframe>
+                            <img src="{{ asset('images/designs/placeholder.jpg') }}" alt="Placeholder Image" class="h-[50%] w-full object-cover" />
                         </div>
                     </div>
-                </div> --}}
-
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/client/home/home.blade.php
+++ b/resources/views/client/home/home.blade.php
@@ -4,7 +4,7 @@
         <div class="hero-content text-center pb-0">
             <div class="max-w-4xl">
                 <h1 class="text-3xl md:text-5xl font-bold mb-4">KHO TÀI NGUYÊN THIẾT KẾ DECOR EVENT-BIRTHDAY-WEDDING</h1>
-                <h5 class="mb-6">Nhận thiết kế thương mại file chất lượng giá tốt và uy tín</h5>
+                <h5 class="mb-6 text-xl">Nhận thiết kế thương mại file chất lượng giá tốt và uy tín</h5>
 
                 <!-- Search Bar Container -->
                 <div class="flex justify-center w-full px-4">
@@ -19,7 +19,7 @@
                                             <path d="m21 21-4.3-4.3"></path>
                                         </g>
                                     </svg>
-                                    <input type="search" class="grow input input-ghost focus:outline-none"
+                                    <input type="search" class="grow input input-ghost focus:outline-none text-lg"
                                         id="search-input"
                                         placeholder="Gõ từ khóa tài nguyên bạn cần"
                                         autocomplete="off" />
@@ -31,7 +31,7 @@
                                     <ul class="py-2 max-h-60 overflow-y-auto text-left"></ul>
                                 </div>
                             </div>
-                            <button onclick="search()" id="btn-search-submit" class="btn btn-soft join-item whitespace-nowrap">Tìm kiếm</button>
+                            <button onclick="search()" id="btn-search-submit" class="btn btn-soft join-item whitespace-nowrap font-semibold">Tìm kiếm</button>
                         </div>
                     </div>
                 </div>
@@ -42,14 +42,14 @@
                         <a href="/products?q={{ $tag->name }}"
                             class="badge badge-soft badge-accent gap-1 p-2 hover:bg-base-200">
                             <i class="las la-search"></i>
-                            <span>{{ $tag->name }}</span>
+                            <span class="text-lg">{{ $tag->name }}</span>
                         </a>
                     @endforeach
                 </div>
 
                 <!-- Categories -->
                 <div class="grid grid-cols-2 md:grid-cols-5 gap-4 mt-7 justify-items-center">
-                    @foreach ($categories as $category)
+                    @foreach ($showcaseCategories as $category)
                         <a href="{{ route('client.shop.category', ['slug' => $category->slug]) }}"
                             class="flex flex-col items-center hover:opacity-80 transition-opacity">
                             <div class="avatar">
@@ -57,7 +57,7 @@
                                     <img src="{{ asset($category->image) }}" alt="{{ $category->name }}" onerror="this.onerror=null;this.src='{{ asset('/images/designs/placeholder.jpg') }}';" />
                                 </div>
                             </div>
-                            <div class="mt-2 text-xs md:text-base">{{ $category->name }}</div>
+                            <div class="mt-2 text-lg md:text-base font-semibold">{{ $category->name }}</div>
                         </a>
                     @endforeach
                 </div>
@@ -70,7 +70,7 @@
         @foreach ($categories as $category)
             <div class="mb-4 mt-6">
                 <a href="javascript:void(0)">
-                    <h1 onclick="location.href='{{ route('client.shop.category', ['slug' => $category->slug]) }}'" class="text-2xl md:text-3xl lg:text-4xl font-bold">
+                    <h1 onclick="location.href='{{ route('client.shop.category', ['slug' => $category->slug]) }}'" class="text-lg md:text-xl lg:text-2xl font-bold">
                         {{ $category->name }}
                     </h1>
                 </a>
@@ -88,7 +88,7 @@
         @endforeach
         <div class="mt-12 mb-4">
             <a href="javascript:void(0)">
-                <h1 onclick="location.href='{{ route('client.shop.index') }}'" class="text-2xl md:text-3xl lg:text-4xl font-bold">
+                <h1 onclick="location.href='{{ route('client.shop.index') }}'" class="text-lg md:text-xl lg:text-2xl font-bold">
                     Mới nhất
                 </h1>
             </a>

--- a/resources/views/client/layouts/master.blade.php
+++ b/resources/views/client/layouts/master.blade.php
@@ -8,7 +8,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
     <title>{{ $title }}</title>
-    
+
     <!-- Fix UI flickering script -->
     <script>
         (function () {
@@ -16,7 +16,7 @@
             document.documentElement.setAttribute("data-theme", theme);
         })();
     </script>
-    
+
     <!-- Scripts -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
     @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/resources/views/client/partials/navigation.blade.php
+++ b/resources/views/client/partials/navigation.blade.php
@@ -10,12 +10,15 @@
                 </svg>
             </label>
             <ul tabindex="0"
-                    class="menu menu-sm dropdown-content bg-base-100 rounded-box z-10 mt-3 w-52 p-2 shadow">
-                <li><a href="/">Trang chủ</a></li>
-                <li><a href="{{ route('client.shop.index') }}">Khám phá</a></li>
+                    class="menu menu-sm dropdown-content bg-base-100 rounded-box z-10 mt-3 p-2 shadow max-h-[86vh] overflow-auto w-max"
+                    style="flex-flow: column;"
+                    >
+                <li><a class="font-semibold" href="/">Trang chủ</a></li>
+                <li><a class="font-semibold" href="{{ route('client.shop.index') }}">Khám phá</a></li>
+                <li><a class="font-semibold" href="{{ route('client.contact.index') }}">Liên hệ</a></li>
                 @foreach ($shared_categories as $category)
                     <li>
-                        <a href="{{ route('client.shop.category', ['slug' => $category->slug]) }}">{{ strtoupper($category->name) }}</a>
+                        <a class="font-bold" href="{{ route('client.shop.category', ['slug' => $category->slug]) }}">{{ strtoupper($category->name) }}</a>
                         <ul class="p-2">
                             @foreach ($category->Children as $child)
                                 <li><a href="{{ route('client.shop.category', ['slug' => $child->slug]) }}">{{ strtoupper($child->name) }}</a></li>
@@ -23,7 +26,6 @@
                         </ul>
                     </li>
                 @endforeach
-                <li><a href="{{ route('client.contact.index') }}">Liên hệ</a></li>
             </ul>
         </div>
         <!-- Your existing logo link -->

--- a/resources/views/client/partials/navigation.blade.php
+++ b/resources/views/client/partials/navigation.blade.php
@@ -13,12 +13,26 @@
                     class="menu menu-sm dropdown-content bg-base-100 rounded-box z-10 mt-3 w-52 p-2 shadow">
                 <li><a href="/">Trang chủ</a></li>
                 <li><a href="{{ route('client.shop.index') }}">Khám phá</a></li>
+                @foreach ($shared_categories as $category)
+                    <li>
+                        <a href="{{ route('client.shop.category', ['slug' => $category->slug]) }}">{{ strtoupper($category->name) }}</a>
+                        <ul class="p-2">
+                            @foreach ($category->Children as $child)
+                                <li><a href="{{ route('client.shop.category', ['slug' => $child->slug]) }}">{{ strtoupper($child->name) }}</a></li>
+                            @endforeach
+                        </ul>
+                    </li>
+                @endforeach
+                <li><a href="{{ route('client.contact.index') }}">Liên hệ</a></li>
             </ul>
         </div>
-        <!-- Logo -->
-        <a class="btn btn-ghost flex items-center" href="/">
-            <svg width="42" height="42" viewBox="0 0 415 415" xmlns="http://www.w3.org/2000/svg"><rect x="82.5" y="290" width="250" height="125" rx="62.5" fill="#1AD1A5"></rect><circle cx="207.5" cy="135" r="130" fill="black" fill-opacity=".3"></circle><circle cx="207.5" cy="135" r="125" fill="white"></circle><circle cx="207.5" cy="135" r="56" fill="#FF9903"></circle></svg>
-            <span class="ml-1 font-bold text-xl">designSC</span>
+        <!-- Your existing logo link -->
+        <a class="btn btn-ghost swap swap-flip w-12 md:w-20 px-0" href="/">
+            <img src="{{ asset('images/logos/logo-nav.png') }}" alt="Logo" class="absolute h-12 w-12 md:h-16 md:w-16 lg:h-16 lg:w-16 xl:h-16 xl:w-16 text-primary swap-off">
+            <img src="{{ asset('images/logos/logo-footer.png') }}" alt="Logo" class="absolute h-12 w-12 md:h-16 md:w-16 lg:h-16 lg:w-16 xl:h-16 xl:w-16 text-primary swap-on">
+        </a>
+        <a class="btn btn-ghost px-0" href="/">
+            <span class="ml-1 font-bold text-xl hidden md:block">THIETKEDECOR</span>
         </a>
     </div>
 
@@ -27,7 +41,17 @@
             <li><a href="/">TRANG CHỦ</a></li>
             <li><a href="{{ route('client.shop.index') }}">KHÁM PHÁ</a></li>
             @foreach ($shared_categories->take(3) as $shared_category)
-                <li><a href="{{ route('client.shop.category', ['slug' => $shared_category->slug]) }}">{{ strtoupper($shared_category->name) }}</a></li>
+            <li>
+                <details class="dropdown">
+                    <summary class="mx-0">{{ strtoupper($shared_category->name) }}</summary>
+                    <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
+                            <li><a class="font-bold text-lg" href="{{ route('client.shop.category', ['slug' => $shared_category->slug]) }}">{{ strtoupper($shared_category->name) }}</a></li>
+                            @foreach ($shared_category->Children as $category)
+                                <li><a href="{{ route('client.shop.category', ['slug' => $category->slug]) }}">{{ strtoupper($category->name) }}</a></li>
+                            @endforeach
+                        </ul>
+                    </details>
+                </li>
             @endforeach
 
             {{-- Dropdown for more categories --}}
@@ -70,6 +94,35 @@
             const newTheme = themeToggle.is(":checked") ? "dark" : "light";
             $("html").attr("data-theme", newTheme);
             localStorage.setItem("theme", newTheme);
+            flipLogo();
         });
+
+        initLogo();
+
+        function flipLogo() {
+            const logo = $(".swap");
+            if (localStorage.getItem("theme") === "light") {
+                if (!logo.hasClass("swap-active")) {
+                    logo.addClass("swap-active");
+                }
+            } else {
+                if (logo.hasClass("swap-active")) {
+                    logo.removeClass("swap-active");
+                }
+            }
+        }
+
+        function initLogo() {
+            const logo = $(".swap");
+            if (localStorage.getItem("theme") === "light") {
+                if (!logo.hasClass("swap-active")) {
+                    logo.addClass("swap-active");
+                }
+            } else {
+                if (logo.hasClass("swap-active")) {
+                    logo.removeClass("swap-active");
+                }
+            }
+        }
     });
 </script>

--- a/resources/views/client/partials/products-loop.blade.php
+++ b/resources/views/client/partials/products-loop.blade.php
@@ -11,7 +11,7 @@
     <div class="card-body absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 text-white flex flex-col justify-center p-4 overflow-hidden">
         {{-- Description --}}
         <div class="overflow-y-scroll">
-            <p class="text-[0.65rem] sm:text-[0.75rem] md:text-[0.85rem]">
+            <p class="text-[0.75rem] sm:text-[0.80rem] md:text-[1rem]">
                 <b>{{ Str::limit($product->name, 80) }}</b> <br> {{ Str::limit($product->description, 150) }}
             </p>
         </div>

--- a/resources/views/client/shop/detail.blade.php
+++ b/resources/views/client/shop/detail.blade.php
@@ -3,7 +3,7 @@
     {{-- resources/views/products/show.blade.php --}}
 <div class="container mx-auto px-4 py-8">
     {{-- Breadcrumb --}}
-    <div class="text-sm breadcrumbs mb-6">
+    <div class="text-lg breadcrumbs mb-6">
         <ul>
             <li><a href="/">Trang chủ</a></li>
             <li><a href="{{ route('client.shop.index') }}">Khám phá</a></li>
@@ -62,45 +62,38 @@
 
             {{-- Category --}}
             <div>
-                <span class="text-gray-600">Danh mục: </span>
-                <a href="{{ route('client.shop.category', ['slug' => $product->Category->slug]) }}" class="link link-hover">{{ $product->Category->name }}</a>
+                <span class="text-gray-600 text-lg">Danh mục: </span>
+                <a href="{{ route('client.shop.category', ['slug' => $product->Category->slug]) }}" class="font-semibold text-lg link link-hover">{{ $product->Category->name }}</a>
             </div>
 
             <div class="flex flex-wrap gap-2 mb-6">
-                <span class="text-gray-600">Tags: </span>
+                <span class="text-gray-600 text-lg">Tags: </span>
                 @foreach ($tags as $tag)
                 <a href="/products?q={{ $tag->name }}" class="btn btn-sm btn-ghost bg-base-200">
-                    <span class="text-base-content/70">{{ $tag->name }}</span>
+                    <span class="text-base-content/70 text-lg font-semibold">{{ $tag->name }}</span>
                 </a>
                 @endforeach
                 <div id="description-content" class="tab-content block">
                     <h3 class="text-xl font-semibold mb-4"></h3>
-                    <p>{{ $product->description }}</p>
+                    <p class="text-lg">{{ $product->description }}</p>
                 </div>
             </div>
 
             {{-- Action Buttons --}}
             <div class="flex flex-wrap gap-4">
-                <button id="downloadButton" class="btn btn-soft" onclick="downloadImage('x')"><svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 28 24" stroke="currentColor">
+                <button id="downloadButton" class="btn btn-soft text-lg" onclick="downloadImage('x')"><svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 28 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8l-8 8-8-8" />
                   </svg>Tải xuống</button>
-                <button class="btn btn-primary flex-1" onclick="location.href='{{ route('client.contact.index') }}'">Liên hệ ngay</button>
+                <button class="btn btn-primary flex-1 text-lg" onclick="location.href='{{ route('client.contact.index') }}'">Liên hệ ngay</button>
             </div>
 
             {{-- Social Share --}}
             <div class="flex gap-2 mt-4" onclick="location.href='{{ route('client.contact.index') }}'">
                 <button class="btn btn-circle btn-ghost">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current">
-                        <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"></path>
-                    </svg>
+                    <img src="{{ asset('images/icons/zalo-light.png') }}" alt="Zalo Icon" class="h-8 w-8 text-primary">
                 </button>
                 <button class="btn btn-circle btn-ghost">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current">
-                        <path d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"></path>
-                    </svg>
-                </button>
-                <button class="btn btn-circle btn-ghost">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-current">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="fill-blue-600">
                         <path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z"></path>
                     </svg>
                 </button>

--- a/resources/views/client/shop/index.blade.php
+++ b/resources/views/client/shop/index.blade.php
@@ -7,10 +7,10 @@
         {{-- Categories - First Row --}}
         <div class="flex flex-wrap gap-2 mb-3">
             <button class="btn btn-sm btn-ghost bg-base-200md" disabled>
-                <span class="text-base-content/70">Danh mục:</span>
+                <span class="text-base-content/70 text-sm">Danh mục:</span>
             </button>
             @foreach ($categories as $category)
-                <a href="{{ route('client.shop.category', ['slug' => $category->slug]) }}" class="btn btn-sm btn-ghost bg-base-200md">
+                <a href="{{ route('client.shop.category', ['slug' => $category->slug]) }}" class="btn btn-sm btn-ghost bg-base-200md text-sm">
                     <span class="text-base-content/70">{{ $category->name }}</span>
                 </a>
             @endforeach
@@ -19,7 +19,7 @@
         {{-- Tags - Second Row --}}
         <div class="flex flex-wrap gap-2 mb-6">
             <button class="btn btn-sm btn-ghost bg-base-200md" disabled>
-                <span class="text-base-content/70">Tags:</span>
+                <span class="text-base-content/70 text-sm">Tags:</span>
             </button>
             @php
                 $i = 0;
@@ -27,7 +27,7 @@
             @foreach ($tags as $tag)
                 @if ($i < 30)
                     <a href="/products?q={{ $tag->name }}" class="btn btn-sm btn-ghost bg-base-200">
-                        <span class="text-base-content/70">{{ $tag->name }}</span>
+                        <span class="text-base-content/70 text-sm">{{ $tag->name }}</span>
                     </a>
                     @php
                         $i++;
@@ -63,13 +63,15 @@
                 </div>
             </div>
 
-            <button class="btn btn-soft" onclick="search()">Tìm kiếm</button>
+            <button class="btn btn-soft font-bold" onclick="search()">Tìm kiếm</button>
         </div>
 
-        {{-- Search Results Title --}}
-        <div class="text-xl font-medium mb-6">
-            Kết quả cho {{ 'từ khóa' }}: <span class="font-bold">{{ request('q') ?? isset($query)?$query:'' }}</span>
-        </div>
+        @if(request('q'))
+            {{-- Search Results Title --}}
+            <div class="text-xl font-medium mb-6">
+                Kết quả cho {{ 'từ khóa' }}: <span class="font-bold">{{ request('q') ?? isset($query)?$query:'' }}</span>
+            </div>
+        @endif
     </div>
 
 


### PR DESCRIPTION
Fixes:
- Limit footer to a maximum of 8 categories, and they must be parent categories
- Optimize the Zalo logo to make it more appropriate
- Font size is too small
- Category text on the homepage is too bold
- Navigation bar should only display parent categories. On desktop: Hover to show child categories. On mobile: Hamburger menu should expand and display parent/child hierarchy
- Replace logo with customer-requested versions for both dark and light themes
- Remove unnecessary social icons, keep only Zalo and Facebook
- Improve the contact page layout to make it more visually appealing and add a fixed image on the right side
- Fix the unbalanced footer layout and correct any typos
- Fix mobile navigation bar items that are missing
- Move some contact information to another section
- Clicking on a parent category should display all its products. Similar functionality applies to child categories